### PR TITLE
Rework Jira reopening logic

### DIFF
--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -90,7 +90,6 @@ func (r *Receiver) Notify(data *alertmanager.Data, hashJiraLabel bool) (bool, er
 		// Issue is closed and should be reopened
 		if issue.Fields.Status.StatusCategory.Key == "done" && issue.Fields.Resolution.Name != r.conf.WontFixResolution {
 			level.Info(r.logger).Log("msg", "issue was recently resolved, reopening", "key", issue.Key, "label", issueGroupLabel)
-			level.Info(r.logger).Log("msg", "ABOUT TO REOPEN", "key", issue.Key, "resolution", fmt.Sprint(issue.Fields.Resolution.Name), "condition", r.conf.WontFixResolution)
 			retry, err := r.reopen(issue.Key)
 			if err != nil {
 				return retry, err

--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -112,7 +112,10 @@ func (r *Receiver) Notify(data *alertmanager.Data, hashJiraLabel bool) (bool, er
 		// Issue is closed and should be reopened
 		if issue.Fields.Resolution != nil || issue.Fields.Status.StatusCategory.Key == "done" {
 			level.Info(r.logger).Log("msg", "issue was recently resolved, reopening", "key", issue.Key, "label", issueGroupLabel)
-			r.reopen(issue.Key)
+			retry, err := r.reopen(issue.Key)
+			if err != nil {
+				return retry, err
+			}
 		}
 
 		// Update summary if needed.


### PR DESCRIPTION
## Why rework the Jiralert notify logic?

In order to provide reliable data and to avoid having fields updating issues, we need to ensure the following:

* The `summary` and `description` fields are not updated if an issue is transitioning to a `Close` state.
* The `summary` and `description` fields are not updated if an issue is already set as `Won't Fix`.
* The `summary` and `description` fields are updated only after `re-opening` the issue.